### PR TITLE
Bug fix for whoami command

### DIFF
--- a/ADOKit/Utilities/UserUtils.cs
+++ b/ADOKit/Utilities/UserUtils.cs
@@ -91,12 +91,13 @@ namespace ADOKit.Utilities
 
                                         userList.Add(new User(directoryAlias, displayName, principalName, descriptor));
                                     }
-                                    
+                                    descriptor = "";
+                                    directoryAlias = "";
+                                    displayName = "";
+                                    principalName = "";
+
                                 }
-                                descriptor = "";
-                                directoryAlias = "";
-                                displayName = "";
-                                principalName = "";
+                                
 
 
                                 break;

--- a/ADOKit/Utilities/UserUtils.cs
+++ b/ADOKit/Utilities/UserUtils.cs
@@ -90,12 +90,11 @@ namespace ADOKit.Utilities
                                     {
 
                                         userList.Add(new User(directoryAlias, displayName, principalName, descriptor));
-                                        descriptor = "";
-                                        directoryAlias = "";
-                                        displayName = "";
-                                        principalName = "";
-   
                                     }
+                                    descriptor = "";
+                                    directoryAlias = "";
+                                    displayName = "";
+                                    principalName = "";
                                 }
 
 

--- a/ADOKit/Utilities/UserUtils.cs
+++ b/ADOKit/Utilities/UserUtils.cs
@@ -91,11 +91,12 @@ namespace ADOKit.Utilities
 
                                         userList.Add(new User(directoryAlias, displayName, principalName, descriptor));
                                     }
-                                    descriptor = "";
-                                    directoryAlias = "";
-                                    displayName = "";
-                                    principalName = "";
+                                    
                                 }
+                                descriptor = "";
+                                directoryAlias = "";
+                                displayName = "";
+                                principalName = "";
 
 
                                 break;

--- a/ADOKit/Utilities/UserUtils.cs
+++ b/ADOKit/Utilities/UserUtils.cs
@@ -91,13 +91,12 @@ namespace ADOKit.Utilities
 
                                         userList.Add(new User(directoryAlias, displayName, principalName, descriptor));
                                     }
-                                    descriptor = "";
-                                    directoryAlias = "";
-                                    displayName = "";
-                                    principalName = "";
-
+                                    
                                 }
-                                
+                                descriptor = "";
+                                directoryAlias = "";
+                                displayName = "";
+                                principalName = "";
 
 
                                 break;

--- a/ADOKit/Utilities/UserUtils.cs
+++ b/ADOKit/Utilities/UserUtils.cs
@@ -91,12 +91,11 @@ namespace ADOKit.Utilities
 
                                         userList.Add(new User(directoryAlias, displayName, principalName, descriptor));
                                     }
-                                    
+                                    descriptor = "";
+                                    directoryAlias = "";
+                                    displayName = "";
+                                    principalName = "";
                                 }
-                                descriptor = "";
-                                directoryAlias = "";
-                                displayName = "";
-                                principalName = "";
 
 
                                 break;


### PR DESCRIPTION
I'm working in a large ADO environment with some 400 users, so the bug I encountered can be hard to reproduce. But when running the `whoami` module I encountered a bug where it showed the output for another user, not the one I am authenticated as. I reproduced this both with PAT and Token from browser. I traced this down to there being multiple duplicate users in this environment with the same displayName and/or principalName, which lead to multiple off-by-one errors in the getAllUsers function. My proposed fix is simply moving the reset functionality for the values after the inner conditional in get getAllUsers function, ensuring the values are "clean". I've confirmed this fix completely resolves the issue. An alternative, which I tested, would be moving it just outside the outer conditional that checks the values. For some reason, this does not fix the issue. I made a few bad commits for this (sorry). Let me know if you need more information.