### PR TITLE
Use continuationToken for users/groups, toLower() on a few more comparisons and a few more error checks

### DIFF
--- a/ADOKit/Modules/Privesc/AddBuildAdmin.cs
+++ b/ADOKit/Modules/Privesc/AddBuildAdmin.cs
@@ -32,6 +32,8 @@ namespace ADOKit.Modules.Privesc
                 Console.WriteLine("[+] SUCCESS: Credentials provided are VALID.");
                 Console.WriteLine("");
 
+                Console.WriteLine("attempting to find user and group descriptors");
+
                 try
                 {
                     // these 2 values are needed to add a user to a group
@@ -44,13 +46,18 @@ namespace ADOKit.Modules.Privesc
                     // iterate through the list of users and find our user. this is way to get the user descriptor.
                     foreach (Objects.User user in userList)
                     {
+                        //debug
+                        //Console.WriteLine("potential user match : " + user.directoryAlias.ToLower());
+
                         // if we have found our user, keep going to get the user descriptor and group descriptor
                         if (user.directoryAlias.ToLower().Equals(username.ToLower()))
                         {
+                            Console.WriteLine("Found user descriptor : " + user.directoryAlias.ToLower());
 
                             // fetch the user details so we can get the descriptor
                             Objects.User ourUser = await Utilities.UserUtils.getUserDetails(credential, url, user.descriptor, user.principalName);
                             userDescriptor = ourUser.descriptor;
+                            //Console.WriteLine("User descriptor: " + groupDescriptor);
 
                             // get a listing of groups for the project we are wanting to add our user to as a build admin
                             List<Objects.Group> groupList = await Utilities.GroupUtils.getGroupPermissionsForProject(credential, url, projectName);
@@ -58,9 +65,12 @@ namespace ADOKit.Modules.Privesc
                             // iterate through the list of groups for the project and get the descriptor for the build administrators group
                             foreach (Objects.Group group in groupList)
                             {
+                                //Console.WriteLine("potential group match : " + group.displayName.ToLower());
+
                                 if (group.displayName.ToLower().Equals("build administrators"))
                                 {
                                     groupDescriptor = group.descriptor;
+                                    Console.WriteLine("Found group descriptor: " + groupDescriptor);
 
                                 }
 
@@ -68,11 +78,22 @@ namespace ADOKit.Modules.Privesc
 
                         }
 
+                    }
 
+                    if (groupDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a group descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+                    if (userDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a user descriptor - there wasn't a match. Stopping.");
+                        return;
                     }
 
                     Console.WriteLine("");
                     Console.WriteLine("[*] INFO: Attempting to add " + username + " to the Build Administrators group for the " + projectName + " project.");
+                    Console.WriteLine("[*] INFO: groupdescriptor " + groupDescriptor + " userdescriptor " + userDescriptor);
                     Console.WriteLine("");
 
                     // add user to group now that we have the user descriptor and group descriptor
@@ -118,21 +139,16 @@ namespace ADOKit.Modules.Privesc
                         Console.WriteLine("");
                     }
 
-
                     Console.WriteLine("");
-
-
-
-
 
                 }
                 catch (Exception ex)
                 {
                     Console.WriteLine("");
                     Console.WriteLine("[-] ERROR: " + ex.Message);
+                    Console.WriteLine("[-] ERROR: " + ex.StackTrace);
                     Console.WriteLine("");
                 }
-
 
             }
 

--- a/ADOKit/Modules/Privesc/AddCollectionAdmin.cs
+++ b/ADOKit/Modules/Privesc/AddCollectionAdmin.cs
@@ -67,7 +67,17 @@ namespace ADOKit.Modules.Privesc
 
                         }
 
+                    }
 
+                    if (groupDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a group descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+                    if (userDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a user descriptor - there wasn't a match. Stopping.");
+                        return;
                     }
 
                     Console.WriteLine("");
@@ -117,11 +127,7 @@ namespace ADOKit.Modules.Privesc
                         Console.WriteLine("");
                     }
 
-
                     Console.WriteLine("");
-
-
-
 
 
                 }
@@ -131,7 +137,6 @@ namespace ADOKit.Modules.Privesc
                     Console.WriteLine("[-] ERROR: " + ex.Message);
                     Console.WriteLine("");
                 }
-
 
             }
 

--- a/ADOKit/Modules/Privesc/AddCollectionBuildAdmin.cs
+++ b/ADOKit/Modules/Privesc/AddCollectionBuildAdmin.cs
@@ -71,6 +71,17 @@ namespace ADOKit.Modules.Privesc
 
                     }
 
+                    if (groupDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a group descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+                    if (userDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a user descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+
                     Console.WriteLine("");
                     Console.WriteLine("[*] INFO: Attempting to add " + username + " to the Project Collection Build Administrators group.");
                     Console.WriteLine("");

--- a/ADOKit/Modules/Privesc/AddCollectionBuildSvc.cs
+++ b/ADOKit/Modules/Privesc/AddCollectionBuildSvc.cs
@@ -70,6 +70,17 @@ namespace ADOKit.Modules.Privesc
 
                     }
 
+                    if (groupDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a group descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+                    if (userDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a user descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+
                     Console.WriteLine("");
                     Console.WriteLine("[*] INFO: Attempting to add " + username + " to the Project Collection Build Service Accounts group.");
                     Console.WriteLine("");
@@ -121,9 +132,6 @@ namespace ADOKit.Modules.Privesc
                     Console.WriteLine("");
 
 
-
-
-
                 }
                 catch (Exception ex)
                 {
@@ -131,7 +139,6 @@ namespace ADOKit.Modules.Privesc
                     Console.WriteLine("[-] ERROR: " + ex.Message);
                     Console.WriteLine("");
                 }
-
 
             }
 

--- a/ADOKit/Modules/Privesc/AddProjectAdmin.cs
+++ b/ADOKit/Modules/Privesc/AddProjectAdmin.cs
@@ -71,7 +71,16 @@ namespace ADOKit.Modules.Privesc
 
                     }
 
-
+                    if (groupDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a group descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+                    if (userDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a user descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
 
                     Console.WriteLine("");
                     Console.WriteLine("[*] INFO: Attempting to add " + username + " to the Project Administrators group for the " + projectName + " project.");
@@ -120,12 +129,7 @@ namespace ADOKit.Modules.Privesc
                         Console.WriteLine("");
                     }
 
-
                     Console.WriteLine("");
-
-
-
-
 
                 }
                 catch (Exception ex)
@@ -134,7 +138,6 @@ namespace ADOKit.Modules.Privesc
                     Console.WriteLine("[-] ERROR: " + ex.Message);
                     Console.WriteLine("");
                 }
-
 
             }
 

--- a/ADOKit/Modules/Privesc/RemoveBuildAdmin.cs
+++ b/ADOKit/Modules/Privesc/RemoveBuildAdmin.cs
@@ -70,6 +70,17 @@ namespace ADOKit.Modules.Privesc
 
                     }
 
+                    if (groupDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a group descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+                    if (userDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a user descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+
                     Console.WriteLine("");
                     Console.WriteLine("[*] INFO: Attempting to remove " + username + " from the Build Administrators group for the " + projectName + " project.");
                     Console.WriteLine("");

--- a/ADOKit/Modules/Privesc/RemoveCollectionAdmin.cs
+++ b/ADOKit/Modules/Privesc/RemoveCollectionAdmin.cs
@@ -70,6 +70,17 @@ namespace ADOKit.Modules.Privesc
 
                     }
 
+                    if (groupDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a group descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+                    if (userDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a user descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+
                     Console.WriteLine("");
                     Console.WriteLine("[*] INFO: Attempting to remove " + username + " from the Project Collection Administrators group.");
                     Console.WriteLine("");

--- a/ADOKit/Modules/Privesc/RemoveCollectionBuildAdmin.cs
+++ b/ADOKit/Modules/Privesc/RemoveCollectionBuildAdmin.cs
@@ -70,6 +70,17 @@ namespace ADOKit.Modules.Privesc
 
                     }
 
+                    if (groupDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a group descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+                    if (userDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a user descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+
                     Console.WriteLine("");
                     Console.WriteLine("[*] INFO: Attempting to remove " + username + " from the Project Collection Build Administrators group.");
                     Console.WriteLine("");

--- a/ADOKit/Modules/Privesc/RemoveCollectionBuildSvc.cs
+++ b/ADOKit/Modules/Privesc/RemoveCollectionBuildSvc.cs
@@ -71,6 +71,17 @@ namespace ADOKit.Modules.Privesc
 
                     }
 
+                    if (groupDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a group descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+                    if (userDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a user descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+
                     Console.WriteLine("");
                     Console.WriteLine("[*] INFO: Attempting to remove " + username + " from the Project Collection Build Service Accounts group.");
                     Console.WriteLine("");

--- a/ADOKit/Modules/Privesc/RemoveCollectionSvc.cs
+++ b/ADOKit/Modules/Privesc/RemoveCollectionSvc.cs
@@ -70,6 +70,17 @@ namespace ADOKit.Modules.Privesc
 
                     }
 
+                    if (groupDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a group descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+                    if (userDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a user descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+
                     Console.WriteLine("");
                     Console.WriteLine("[*] INFO: Attempting to remove " + username + " from the Project Collection Service Accounts group.");
                     Console.WriteLine("");

--- a/ADOKit/Modules/Privesc/RemoveProjectAdmin.cs
+++ b/ADOKit/Modules/Privesc/RemoveProjectAdmin.cs
@@ -70,6 +70,17 @@ namespace ADOKit.Modules.Privesc
 
                     }
 
+                    if (groupDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a group descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+                    if (userDescriptor == "")
+                    {
+                        Console.WriteLine("[*] ERROR We didn't find a user descriptor - there wasn't a match. Stopping.");
+                        return;
+                    }
+
                     Console.WriteLine("");
                     Console.WriteLine("[*] INFO: Attempting to remove " + username + " from the Project Administrators group for the " + projectName + " project.");
                     Console.WriteLine("");
@@ -119,9 +130,6 @@ namespace ADOKit.Modules.Privesc
 
 
                     Console.WriteLine("");
-
-
-
 
 
                 }

--- a/ADOKit/Modules/Recon/SearchUser.cs
+++ b/ADOKit/Modules/Recon/SearchUser.cs
@@ -46,7 +46,7 @@ namespace ADOKit.Modules.Recon
                     {
 
                         // list the user if there is a match for what is being searched for
-                        if (user.directoryAlias.ToLower().Contains(search.ToLower()))
+                        if (user.directoryAlias.ToLower().Contains(search.ToLower()) || user.principalName.ToLower().Contains(search.ToLower()) )
                         {
 
                             Console.WriteLine("{0,50} | {1,50} | {2,50}", user.directoryAlias, user.displayName, user.principalName);
@@ -57,7 +57,6 @@ namespace ADOKit.Modules.Recon
                     Console.WriteLine("");
 
 
-
                 }
                 catch (Exception ex)
                 {
@@ -65,7 +64,6 @@ namespace ADOKit.Modules.Recon
                     Console.WriteLine("[-] ERROR: " + ex.Message);
                     Console.WriteLine("");
                 }
-
 
             }
 

--- a/ADOKit/Modules/Recon/Whoami.cs
+++ b/ADOKit/Modules/Recon/Whoami.cs
@@ -83,7 +83,8 @@ namespace ADOKit.Modules.Recon
                                 // go through each group member in the group and if our user matches, display it
                                 foreach (Objects.GroupMember member in groupMemberList)
                                 {
-                                    if (member.mailAddress.ToLower().Equals(user.principalName))
+                                    //Console.WriteLine("whoami Checking user " + user.principalName.ToLower() + "against group " + group.principalName + ", member " + member.mailAddress.ToLower());
+                                    if (member.mailAddress.ToLower().Equals(user.principalName.ToLower()))
                                     {
 
                                         Console.WriteLine("{0,70} | {1,50} | {2,50}", group.principalName, group.displayName, group.description);
@@ -102,17 +103,14 @@ namespace ADOKit.Modules.Recon
                     Console.WriteLine("");
 
 
-
-
-
                 }
                 catch (Exception ex)
                 {
                     Console.WriteLine("");
                     Console.WriteLine("[-] ERROR: " + ex.Message);
+                    Console.WriteLine("[-] ERROR: " + ex.StackTrace);
                     Console.WriteLine("");
                 }
-
 
             }
 

--- a/ADOKit/Utilities/FileUtils.cs
+++ b/ADOKit/Utilities/FileUtils.cs
@@ -142,15 +142,12 @@ namespace ADOKit.Utilities
 
             return filesList;
 
-
         }
-
 
 
         // get the file contents at a given file URL
         public static async Task<string> getFileContents(string credentials, string fileURL)
         {
-
 
             // this is the file content to return
             string fileContents = "";
@@ -215,7 +212,7 @@ namespace ADOKit.Utilities
 
             foreach (Objects.File file in fileList)
             {
-                if (file.fileURL.Equals(url))
+                if (file.fileURL.ToLower().Equals(url.ToLower()))
                 {
                     doesItExist = true;
                 }

--- a/ADOKit/Utilities/RepoUtils.cs
+++ b/ADOKit/Utilities/RepoUtils.cs
@@ -32,7 +32,7 @@ namespace ADOKit.Utilities
 
 
                 // web request to get all repos in a given project
-                HttpWebRequest webRequest = (HttpWebRequest)System.Net.WebRequest.Create(projectURL + "/_apis/git/repositories?api-version=7.0");
+                HttpWebRequest webRequest = (HttpWebRequest)System.Net.WebRequest.Create(projectURL + "/_apis/git/repositories?includeHidden=true&api-version=7.0");
                 if (webRequest != null)
                 {
 

--- a/ADOKit/Utilities/ServiceConnectionUtils.cs
+++ b/ADOKit/Utilities/ServiceConnectionUtils.cs
@@ -32,7 +32,7 @@ namespace ADOKit.Utilities
             {
 
                 // web request to get all service connections for a user
-                HttpWebRequest webRequest = (HttpWebRequest)System.Net.WebRequest.Create(url + "/" + project + "/_apis/serviceendpoint/endpoints?api-version=7.0");
+                HttpWebRequest webRequest = (HttpWebRequest)System.Net.WebRequest.Create(url + "/" + project + "/_apis/serviceendpoint/endpoints?includeFailed=true&api-version=7.0");
                 if (webRequest != null)
                 {
 
@@ -122,8 +122,6 @@ namespace ADOKit.Utilities
                                     id = jsonResult.Value.ToString();
                                 }
 
-
-
                                 break;
                             case "Boolean":
                                 break;
@@ -149,7 +147,6 @@ namespace ADOKit.Utilities
 
             return serviceConnectionList;
         }
-
 
 
         // determine whether we already have a service connection in our list by the given unique id

--- a/ADOKit/Utilities/UserUtils.cs
+++ b/ADOKit/Utilities/UserUtils.cs
@@ -22,11 +22,20 @@ namespace ADOKit.Utilities
             // this is the list of users to return
             List<User> userList = new List<User>();
 
-
             // ignore SSL errors
             ServicePointManager.ServerCertificateValidationCallback = delegate (object s, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) { return true; };
             ServicePointManager.Expect100Continue = true;
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
+            // parse the JSON output and display results
+            JsonTextReader jsonResult;
+
+            string propName = "";
+            string directoryAlias = "";
+            string displayName = "";
+            string principalName = "";
+            string descriptor = "";
+
 
             try
             {
@@ -34,45 +43,82 @@ namespace ADOKit.Utilities
                 url = url.Replace("dev.azure.com", "vssps.dev.azure.com");
 
                 // web request to get all users
-                HttpWebRequest webRequest = (HttpWebRequest)System.Net.WebRequest.Create(url + "/_apis/graph/users?api-version=7.0-preview.1");
-                if (webRequest != null)
+                string contToken = "";
+                string content = "";
+
+                HttpWebRequest webRequest = null;
+
+                // loop until we don't have a continuationToken in the response. if we do, fetch more 
+                do
                 {
+                    content = ""; // empty our buffer 
 
-                    // set header values
-                    webRequest.Method = "GET";
-                    webRequest.ContentType = "application/json";
-                    webRequest.UserAgent = "ADOKit-21e233d4334f9703d1a3a42b6e2efd38";
-
-                    // if cookie was provided
-                    if (credentials.ToLower().Contains("userauthentication="))
+                    if (contToken != "")
                     {
-                        webRequest.Headers.Add("Cookie", "X-VSS-UseRequestRouting=True; " + credentials);
-
+                        webRequest = (HttpWebRequest)System.Net.WebRequest.Create(url + "/_apis/graph/users?api-version=7.0-preview.1&continuationToken=" + contToken);
                     }
-
-                    // otherwise PAT was provided
                     else
                     {
-                        webRequest.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(":" + credentials)));
+                        webRequest = (HttpWebRequest)System.Net.WebRequest.Create(url + "/_apis/graph/users?api-version=7.0-preview.1");
                     }
 
-                    // get web response
-                    HttpWebResponse myWebResponse = (HttpWebResponse)await webRequest.GetResponseAsync();
-                    string content;
-                    var reader = new StreamReader(myWebResponse.GetResponseStream());
-                    content = reader.ReadToEnd();
+                    if (webRequest != null)
+                    {
 
+                        // set header values
+                        webRequest.Method = "GET";
+                        webRequest.ContentType = "application/json";
+                        webRequest.UserAgent = "ADOKit-21e233d4334f9703d1a3a42b6e2efd38";
+
+                        // if cookie was provided
+                        if (credentials.ToLower().Contains("userauthentication="))
+                        {
+                            webRequest.Headers.Add("Cookie", "X-VSS-UseRequestRouting=True; " + credentials);
+                        }
+                        // otherwise PAT was provided
+                        else
+                        {
+                            webRequest.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(":" + credentials)));
+                        }
+
+
+
+                        // get web response
+                        HttpWebResponse myWebResponse = (HttpWebResponse)await webRequest.GetResponseAsync();
+
+                        var reader = new StreamReader(myWebResponse.GetResponseStream());
+                        content += reader.ReadToEnd();
+
+                        // if there's a continuationToken header we need to send the request to get
+                        // a bit more ... and a bit more until there isn't a continuation token 
+
+                        contToken = "";
+                        // get the X-ms-continuationtoken header value
+                        for (int i = 0; i < myWebResponse.Headers.Count; i++)
+                        {
+
+                            // grab the header value
+                            if (myWebResponse.Headers.Keys[i].ToString().ToLower().Equals("x-ms-continuationtoken"))
+                            {
+                                //Console.WriteLine("[+] Response header : " + myWebResponse.Headers.Keys[i].ToString() + " / " + myWebResponse.Headers[i]);
+
+                                contToken = myWebResponse.Headers[i];
+                            }
+                        }
+
+                    }
 
                     // parse the JSON output and display results
-                    JsonTextReader jsonResult = new JsonTextReader(new StringReader(content));
+                    jsonResult = new JsonTextReader(new StringReader(content));
 
-                    string propName = "";
-                    string directoryAlias = "";
-                    string displayName = "";
-                    string principalName = "";
-                    string descriptor = "";
+                    propName = "";
+                    directoryAlias = "";
+                    displayName = "";
+                    principalName = "";
+                    descriptor = "";
 
-                    // read the json results
+
+                    // read the json results 
                     while (jsonResult.Read())
                     {
                         switch (jsonResult.TokenType.ToString())
@@ -94,7 +140,7 @@ namespace ADOKit.Utilities
                                         directoryAlias = "";
                                         displayName = "";
                                         principalName = "";
-   
+
                                     }
                                 }
 
@@ -145,21 +191,20 @@ namespace ADOKit.Utilities
                         }
 
                     }
-
-                }
+                } while (contToken != "") ;
 
             }
             catch (Exception ex)
             {
                 Console.WriteLine("");
                 Console.WriteLine("[-] ERROR: " + ex.Message);
+                Console.WriteLine("[-] ERROR: " + ex.StackTrace);
                 Console.WriteLine("");
             }
 
 
             return userList;
         }
-
 
 
         // get details for a specific user
@@ -289,6 +334,7 @@ namespace ADOKit.Utilities
             {
                 Console.WriteLine("");
                 Console.WriteLine("[-] ERROR: " + ex.Message);
+                Console.WriteLine("[-] ERROR: " + ex.StackTrace);
                 Console.WriteLine("");
             }
 
@@ -409,6 +455,7 @@ namespace ADOKit.Utilities
             catch (Exception ex)
             {
                 Console.WriteLine("");
+                Console.WriteLine("[-] ERROR: " + ex.StackTrace);
                 Console.WriteLine("[-] ERROR: " + ex.Message);
                 Console.WriteLine("");
             }
@@ -416,12 +463,6 @@ namespace ADOKit.Utilities
 
             return membershipList;
         }
-
-
-
-
-
-
 
         // get who the current user is
         public static async Task<string> getCurrentUser(string credentials, string url)
@@ -466,10 +507,14 @@ namespace ADOKit.Utilities
                     // get the X-Vss-Userdata header value
                     for (int i = 0; i < myWebResponse.Headers.Count; i++)
                     {
+			//DEBUG
+                        //Console.WriteLine("[+] Response header : " + myWebResponse.Headers.Keys[i].ToString() + " / " + myWebResponse.Headers[i]);
+
                         // grab the header value
                         if (myWebResponse.Headers.Keys[i].ToString().ToLower().Equals("x-vss-userdata"))
                         {
                             theUser = myWebResponse.Headers[i];
+                        
                         }
 
 
@@ -480,10 +525,12 @@ namespace ADOKit.Utilities
             }
             catch (Exception ex)
             {
+                System.Console.WriteLine("Exception " + ex.StackTrace);
                 return theUser;
             }
 
             return theUser;
+
 
         }
 
@@ -496,7 +543,7 @@ namespace ADOKit.Utilities
 
             foreach (Objects.User user in userList)
             {
-                if (user.principalName.Equals(principalName))
+                if (user.principalName.ToLower().Equals(principalName.ToLower()))
                 {
                     doesItExist = true;
                 }
@@ -504,7 +551,6 @@ namespace ADOKit.Utilities
 
             return doesItExist;
         }
-
 
     }
 }

--- a/ADOKit/Utilities/WebUtils.cs
+++ b/ADOKit/Utilities/WebUtils.cs
@@ -52,6 +52,12 @@ namespace ADOKit.Utilities
                         webRequest.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(":" + credentials)));
                     }
 
+                    // dump webrequest headers for debug 
+                    /* for (int i = 0; i < webRequest.Headers.Count; i++)
+                    {
+                        Console.WriteLine("[+] Request header : " + webRequest.Headers.Keys[i].ToString() + " / " + webRequest.Headers[i]);
+                    } */
+
                     // get web response and status code
                     HttpWebResponse myWebResponse = (HttpWebResponse)await webRequest.GetResponseAsync();
                     string statusCode = myWebResponse.StatusCode.ToString();
@@ -79,7 +85,6 @@ namespace ADOKit.Utilities
         {
 
             string orgID = "";
-
 
             // ignore SSL errors
             ServicePointManager.ServerCertificateValidationCallback = delegate (object s, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) { return true; };


### PR DESCRIPTION
A few things that were tripping me up on a reasonably large environment, where they'd use capital letters for some usernames and other things where I'm not sure if they were being expected.

Loop on fetching users and groups til continuationToken comes back empty.

A few error checks so if we didn't find a user match for privesc - e.g. adding that user to a group - it will say so and abort. 